### PR TITLE
feat: improve showdown flow and player indicators

### DIFF
--- a/backend/src/socket/gameSocket.js
+++ b/backend/src/socket/gameSocket.js
@@ -1,8 +1,8 @@
-﻿import jwt from 'jsonwebtoken'
+import jwt from 'jsonwebtoken'
 import { User } from '../models/User.js'
 import { GameRoom } from '../models/GameRoom.js'
 import { PokerGame } from '../services/PokerGame.js'
-import { checkAchievements, ACHIEVEMENTS } from '../services/achievements.js'
+import { checkAchievements } from '../services/achievements.js'
 
 // Store active game rooms
 const activeRooms = new Map()
@@ -352,12 +352,416 @@ export const handleSocketConnection = (socket, io) => {
 
         // Process AI actions (1 second delay to let users see the process)
         console.log('Preparing to process AI actions...')
+        setTimeout(async () => {
+          console.log('Starting AI action processing')
+          await processAIActions(game, socket.currentRoomId, io)
+        }, AI_ACTION_DELAY_MS)
+
+        // Check if game is finished
+        if (game.isGameFinished()) {
+          await handleGameFinish(game, socket.currentRoomId, io)
+        }
+      } else {
+        socket.emit('action_error', { error: result.error })
+      }
+
+    } catch (error) {
+      console.error('Game action error:', error)
+      socket.emit('error', { error: 'Action failed' })
+    }
+  })
+
+  // Start game
+  socket.on('start_game', async () => {
+    try {
+      if (!socket.userId || !socket.currentRoomId) {
+        socket.emit('error', { error: 'Invalid game state' })
+        return
+      }
+
+      const game = activeRooms.get(socket.currentRoomId)
+      if (!game) {
+        socket.emit('error', { error: 'Game does not exist' })
+        return
+      }
+
+      const room = await GameRoom.findById(socket.currentRoomId)
+      if (room.creator_id !== socket.userId) {
+        socket.emit('error', { error: 'Only the host can start the game' })
+        return
+      }
+
+      let gameState = null
+      let actionDescription = 'Game started'
+
+      if (!game.gameStarted) {
+        const result = game.startGame()
+        if (!result.success) {
+          socket.emit('error', { error: result.error })
+          return
+        }
+        gameState = game.getGameState()
+      } else if (game.gameFinished) {
+        const nextHand = game.startNextHand()
+        if (!nextHand.success) {
+          await GameRoom.updateStatus(socket.currentRoomId, 'waiting')
+          await GameRoom.updatePlayers(socket.currentRoomId, game.getPlayers())
+          const waitingState = game.getGameState()
+          await GameRoom.updateGameState(socket.currentRoomId, waitingState)
+          broadcastPlayerList(io, socket.currentRoomId, game)
+          io.to(socket.currentRoomId).emit('game_update', {
+            gameState: waitingState,
+            lastAction: null,
+            message: nextHand.error
+          })
+          socket.emit('error', { error: nextHand.error || 'Unable to start next hand' })
+          return
+        }
+        gameState = nextHand.gameState
+        actionDescription = 'Next hand started'
+      } else {
+        socket.emit('error', { error: 'Game is already in progress' })
+        return
+      }
+
+      await GameRoom.updateStatus(socket.currentRoomId, 'playing')
+      await GameRoom.updatePlayers(socket.currentRoomId, game.getPlayers())
+      await GameRoom.updateGameState(socket.currentRoomId, gameState)
+
+      io.to(socket.currentRoomId).emit('game_started', {
+        gameState
+      })
+      io.to(socket.currentRoomId).emit('game_update', {
+        gameState,
+        lastAction: null
+      })
+      broadcastPlayerList(io, socket.currentRoomId, game)
+
+      await processAIActions(game, socket.currentRoomId, io)
+
+      console.log(`${actionDescription} in room ${socket.currentRoomId}`)
+
+    } catch (error) {
+      console.error('Start game error:', error)
+      socket.emit('error', { error: 'Failed to start game' })
+    }
+  })
+
+  // Reset game
+  socket.on('reset_game', async () => {
+    try {
+      if (!socket.userId || !socket.currentRoomId) {
+        socket.emit('error', { error: 'Invalid game state' })
+        return
+      }
+
+      const game = activeRooms.get(socket.currentRoomId)
+      if (!game) {
+        socket.emit('error', { error: 'Game does not exist' })
+        return
+      }
+
+      // Reset game state
+      game.gameStarted = false
+      game.gameFinished = false
+      game.phase = 'waiting'
+      game.pot = 0
+      game.currentBet = 0
+      game.currentPlayerIndex = 0
+      game.communityCards = []
+      game.actionHistory = []
+
+      // Reset player state
+      game.players.forEach(player => {
+        player.cards = []
+        player.currentBet = 0
+        player.totalBet = 0
+        player.folded = false
+        player.allIn = false
+        player.active = player.chips > 0
+      })
+
+      // Update room status
+      await GameRoom.updateStatus(socket.currentRoomId, 'waiting')
+      await GameRoom.updateGameState(socket.currentRoomId, game.getGameState())
+
+      // Broadcast game reset
+      io.to(socket.currentRoomId).emit('game_reset', {
+        gameState: game.getGameState(),
+        message: 'Game has been reset'
+      })
+
+      console.log(`Game reset in room ${socket.currentRoomId}`)
+
+    } catch (error) {
+      console.error('Reset game error:', error)
+      socket.emit('error', { error: 'Failed to reset game' })
+    }
+  })
+
+  socket.on('set_ai_count', async (data) => {
+    const requested = parseInt(
+      data?.totalPlayers ?? data?.desiredSeatCount ?? data?.count,
+      10
+    )
+    const updated = await updateSeatCount(socket, io, () => requested)
+    if (updated !== null) {
+      console.log(`Room ${socket.currentRoomId} adjusted target seat count to ${updated} (requested: ${requested})`)
+    }
+  })
+
+  socket.on('add_ai', async () => {
+    const result = await adjustAIPlayers(socket, io, 1)
+    if (result !== null) {
+      console.log(`Room ${socket.currentRoomId} added AI, current player count: ${result}`)
+    }
+  })
+
+  socket.on('remove_ai', async () => {
+    const result = await adjustAIPlayers(socket, io, -1)
+    if (result !== null) {
+      console.log(`Room ${socket.currentRoomId} removed AI, current player count: ${result}`)
+    }
+  })
+
+  // Chat message
+  socket.on('send_chat_message', async (data) => {
+    try {
+      if (!socket.userId || !socket.currentRoomId) {
+        socket.emit('error', { error: 'Please join a room first' })
+        return
+      }
+
+      const { message } = data
+      if (!message || message.trim().length === 0) {
+        return
+      }
+
+      // Message length limit
+      const trimmedMessage = message.trim().substring(0, 200)
+
+      // Broadcast chat message to all players in room
+      io.to(socket.currentRoomId).emit('chat_message', {
+        userId: socket.userId,
+        username: socket.username,
+        message: trimmedMessage,
+        timestamp: Date.now()
+      })
+
+      console.log(`Chat message [${socket.currentRoomId}] ${socket.username}: ${trimmedMessage}`)
+
+    } catch (error) {
+      console.error('Send chat message error:', error)
+      socket.emit('error', { error: 'Failed to send message' })
+    }
+  })
+
+  // Disconnect
+  socket.on('disconnect', async () => {
+    console.log(`Socket disconnected: ${socket.id}`)
+    await handleLeaveRoom(socket, io)
+  })
+}
+
+// Handle player leaving room
+const handleLeaveRoom = async (socket, io) => {
+  if (!socket.currentRoomId || !socket.userId) {
+    return
+  }
+
+  const roomId = socket.currentRoomId
+  const game = activeRooms.get(roomId)
+
+  if (game) {
+    const leavingPlayer = Array.isArray(game.players) ? game.players.find(player => player.id === socket.userId) : null
+    const leavingPlayerName = leavingPlayer?.name || null
+
+    game.removePlayer(socket.userId)
+
+    const realPlayers = typeof game.countRealPlayers === 'function'
+      ? game.countRealPlayers()
+      : game.getPlayers().filter(player => !player.isAI).length
+
+    if (realPlayers === 0) {
+      activeRooms.delete(roomId)
+      await GameRoom.updatePlayers(roomId, [])
+      await GameRoom.updateGameState(roomId, null)
+      await GameRoom.updateStatus(roomId, 'waiting')
+      broadcastPlayerList(io, roomId, null)
+      console.log(`Room ${roomId} has been cleared`)
+    } else {
+      if (!game.gameStarted && typeof game.syncAIPlayers === 'function') {
+        game.syncAIPlayers()
+      }
+
+      await GameRoom.updatePlayers(roomId, game.getPlayers())
+      await GameRoom.updateGameState(roomId, game.getGameState())
+
+      io.to(roomId).emit('player_left', {
+        playerId: socket.userId,
+        playerName: leavingPlayerName,
+        players: game.getPlayers(),
+        gameState: game.getGameState()
+      })
+      broadcastPlayerList(io, roomId, game)
+    }
+  }
+
+  socket.leave(roomId)
+  socket.currentRoomId = null
+  console.log(`Player ${socket.username} left room ${roomId}`)
+}
+
+
+// Process consecutive AI actions
+const processAIActions = async (game, roomId, io) => {
+  try {
+    const playerCount = typeof game.getPlayers === 'function' ? game.getPlayers().length : (game.players?.length || 0)
+    const maxAIActions = Math.max(60, playerCount * 12) // Prevent infinite loops and ensure sufficient AI action attempts
+    let aiActionCount = 0
+
+    while (aiActionCount < maxAIActions) {
+      const aiResult = game.processAIAction()
+
+      if (!aiResult) {
+        // No AI needs to act, or game is finished
+        break
+      }
+
+      aiActionCount++
+
+      // Broadcast AI action
+      if (aiResult.actionSummary) {
+        io.to(roomId).emit('ai_action', aiResult.actionSummary)
+      } else {
+        io.to(roomId).emit('ai_action', {
+          playerId: aiResult.playerId,
+          playerName: aiResult.playerName,
+          action: aiResult.action,
+          amount: aiResult.amount ?? 0
+        })
+      }
+
+      // Broadcast game state update
+      io.to(roomId).emit('game_update', {
+        gameState: aiResult.gameState,
+        lastAction: aiResult.actionSummary || {
+          action: aiResult.action,
+          type: aiResult.action,
+          playerId: aiResult.playerId,
+          playerName: aiResult.playerName,
+          amount: aiResult.amount ?? 0,
+          timestamp: Date.now(),
+          phase: aiResult.gameState?.phase
+        }
+      })
+
+      // Update game state in database
+      await GameRoom.updateGameState(roomId, aiResult.gameState)
+
+      // AI action interval delay to let players see AI actions clearly
+      await new Promise(resolve => setTimeout(resolve, AI_ACTION_DELAY_MS))
+
+      // Check if game is finished
+      if (game.isGameFinished()) {
+        await handleGameFinish(game, roomId, io)
+        break
+      }
+    }
+
+    if (aiActionCount >= maxAIActions) {
+      console.warn(`AI action loop limit reached for room ${roomId} after ${aiActionCount} actions`)
+    }
+
+  } catch (error) {
+    console.error('AI action processing error:', error)
+  }
+}
+
+// Handle game finish
+const handleGameFinish = async (game, roomId, io) => {
+  try {
+    const results = game.getGameResults()
+
+    if (!results) {
+      console.warn(`Game results for room ${roomId} are empty, cannot settle`)
+      return
+    }
+
+    const playerAchievements = {}
+
+    for (const player of results.players) {
+      const playerState = Array.isArray(game.players) ? game.players.find(p => p.id === player.id) : null
+      if (playerState?.isAI) {
+        continue
+      }
+
+      await User.updateChips(player.id, player.finalChips)
+
+      const isWinner = Array.isArray(results.winners)
+        ? results.winners.some((winner) => winner.id === player.id)
+        : results.winner && results.winner.id === player.id
+
+      await User.updateGameStats(player.id, {
+        gamesPlayed: 1,
+        gamesWon: isWinner ? 1 : 0,
+        chipsWon: Math.max(0, player.chipsChange),
+        chipsLost: Math.max(0, -player.chipsChange)
+      })
+
+      const userStats = await User.getStats(player.id)
+      const userAchievements = await User.getAchievements(player.id)
+      const newAchievements = checkAchievements(userStats, userAchievements)
+
+      if (newAchievements.length > 0) {
+        const achievementIds = newAchievements.map(a => a.id)
+        await User.addAchievements(player.id, achievementIds)
+
+        const totalReward = newAchievements.reduce((sum, a) => sum + a.reward, 0)
+        if (totalReward > 0) {
+          const updatedUser = await User.findById(player.id)
+          await User.updateChips(player.id, updatedUser.chips + totalReward)
+        }
+
+        playerAchievements[player.id] = newAchievements
+      }
+    }
+
+    const finalState = game.getGameState()
+
+    await GameRoom.updateStatus(roomId, 'finished')
+    await GameRoom.updatePlayers(roomId, game.getPlayers())
+    await GameRoom.updateGameState(roomId, finalState)
+
+    io.to(roomId).emit('game_finished', {
+      results,
+      winner: results.winner,
+      winners: Array.isArray(results.winners) ? results.winners : (results.winner ? [results.winner] : []),
+      pot: results.pot,
+      gameState: finalState
+    })
+
+    broadcastPlayerList(io, roomId, game)
+
+    for (const [playerId, achievements] of Object.entries(playerAchievements)) {
+      io.to(roomId).emit('achievements_unlocked', {
+        playerId,
+        achievements: achievements.map(a => ({
+          id: a.id,
+          name: a.name,
+          description: a.description,
+          icon: a.icon,
+          reward: a.reward
+        }))
+      })
+    }
+
+    console.log(`Game finished in room ${roomId}, winner: ${results.winner.name}`)
 
   } catch (error) {
     console.error('Handle game finish error:', error)
   }
 }
-
 
 
 

--- a/frontend/src/views/Game.vue
+++ b/frontend/src/views/Game.vue
@@ -1645,8 +1645,9 @@ onBeforeUnmount(() => {
 }
 
 .seat.active .seat-frame {
-  border-color: #f59e0b;
-  box-shadow: 0 24px 60px rgba(245, 158, 11, 0.4);
+  border-color: #facc15;
+  border-width: 2px;
+  box-shadow: 0 24px 60px rgba(250, 204, 21, 0.45);
   background: rgba(30, 41, 59, 0.92);
 }
 


### PR DESCRIPTION
## Summary
- highlight the active seat with a clock icon, brighter framing, and fold badges while moving the round banner out of the player path
- keep the final showdown state visible with community cards and active hands, including a compact summary of winners and pot details
- track finished hands and last pot amounts in the store so hosts must manually start the next deal after a showdown

## Testing
- npm run lint *(fails: no eslint configuration present)*

------
https://chatgpt.com/codex/tasks/task_e_68de373203ac832a9e26eb82f88bc0c5