### PR TITLE
feat: improve seating order and table visuals

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,11 +5,16 @@ import 'element-plus/dist/index.css'
 import router from './router'
 import App from './App.vue'
 import './assets/styles/main.css'
+import { useUserStore } from './stores/user'
 
 const app = createApp(App)
 const pinia = createPinia()
 
 app.use(pinia)
+
+const userStore = useUserStore()
+userStore.initFromStorage()
+
 app.use(router)
 app.use(ElementPlus)
 

--- a/frontend/src/stores/game.js
+++ b/frontend/src/stores/game.js
@@ -27,6 +27,23 @@ export const useGameStore = defineStore('game', () => {
   const isAuthenticated = ref(false)
   const error = ref(null)
 
+  const normalizePlayers = (list = []) => {
+    if (!Array.isArray(list)) return []
+
+    return [...list].sort((a, b) => {
+      const seatA = Number.isInteger(a?.seatIndex) ? a.seatIndex : Number.MAX_SAFE_INTEGER
+      const seatB = Number.isInteger(b?.seatIndex) ? b.seatIndex : Number.MAX_SAFE_INTEGER
+
+      if (seatA !== seatB) {
+        return seatA - seatB
+      }
+
+      const idA = (a?.id || '').toString()
+      const idB = (b?.id || '').toString()
+      return idA.localeCompare(idB)
+    })
+  }
+
   // Computed
   const isMyTurn = computed(() => {
     if (
@@ -194,7 +211,7 @@ export const useGameStore = defineStore('game', () => {
 
   function handlePlayerListUpdated(data) {
     if (data && Array.isArray(data.players)) {
-      players.value = data.players
+      players.value = normalizePlayers(data.players)
     }
     if (data && typeof data.desiredSeatCount === 'number') {
       desiredSeatCount.value = data.desiredSeatCount
@@ -275,7 +292,7 @@ export const useGameStore = defineStore('game', () => {
    * @param {Object} state - Game state
    */
   function updateGameState(state) {
-    if (state.players) players.value = state.players
+    if (state.players) players.value = normalizePlayers(state.players)
     if (state.communityCards) communityCards.value = state.communityCards
     if (state.pot !== undefined) pot.value = state.pot
     if (state.currentBet !== undefined) currentBet.value = state.currentBet


### PR DESCRIPTION
## Summary
- ensure the poker engine tracks seat indices and reorders players clockwise so turn progression stays accurate when seats change
- normalize the client seat list by index and emphasize check actions with new styling cues
- refresh the table presentation with a relocated round indicator, white-faced cards, refined suit colors, and an updated card back design

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68de543368c0832abb089408ac7177ca