### PR TITLE
Ensure CI checks backend and frontend dev servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  backend:
+    name: Backend Tests and Dev Boot
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify dev server starts
+        run: |
+          set +e
+          timeout --signal=SIGINT 20 npm run dev
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
+            echo "Dev server exited with status $status"
+            exit "$status"
+          fi
+
+  frontend:
+    name: Frontend Build and Dev Boot
+    runs-on: ubuntu-latest
+    needs: backend
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Verify dev server starts
+        run: |
+          set +e
+          timeout --signal=SIGINT 20 npm run dev
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
+            echo "Dev server exited with status $status"
+            exit "$status"
+          fi


### PR DESCRIPTION
## Summary
- extend the CI workflow to keep backend tests and frontend builds
- add timeout-guarded checks that start each dev server to ensure they boot without crashing

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68de55596aac832abc42b3e229b8725b